### PR TITLE
add option to `linkify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # markdown-it-headinganchor
 
-This is a [markdown-it](https://github.com/markdown-it/markdown-it) plugin that adds an anchor (i.e., `<a name=\"blah\"...>`) to headings. 
+This is a [markdown-it](https://github.com/markdown-it/markdown-it) plugin that adds an anchor (i.e., `<a name=\"blah\"...>`) to headings.
 
 There are other plugins that add an `id` attribute ([valeriangalliat/markdown-it-anchor](https://github.com/valeriangalliat/markdown-it-anchor)) or `name` attribute ([leff/markdown-it-named-headers](https://github.com/leff/markdown-it-named-headers)) to headings, but neither of these approches work for adding anchors that are not stripped out of email.
 
@@ -46,7 +46,8 @@ md.use(require('markdown-it-headinganchor'), {
   anchorClass: 'my-class-name', // default: 'markdown-it-headinganchor'
   addHeadingID: true,           // default: true
   addHeadingAnchor: true,       // default: true
-  slugify: function(str, md) {} // default: 'My Heading' -> 'MyHeading'
+  slugify: function(str, md) {}, // default: 'My Heading' -> 'MyHeading'
+  linkify: true                 // default: true
 });
 md.render('# My Heading');
 ```

--- a/index.js
+++ b/index.js
@@ -36,14 +36,13 @@ function makeRule(md, options) {
 
       if (options.addHeadingAnchor) {
         var anchorToken = new state.Token('html_inline', '', 0);
-        var anchorContent = (options.linkify) ? headingInlineToken.content : '';
         anchorToken.content =
           '<a name="' +
           anchorName +
           '" class="' +
           options.anchorClass +
-          '" href="#">'+
-          anchorContent +
+          '" href="#' + ((options.linkify) ? anchorName : '') + '">' +
+          ((options.linkify) ? headingInlineToken.content : '') +
           '</a>';
 
         headingInlineToken.children.unshift(anchorToken);

--- a/index.js
+++ b/index.js
@@ -36,14 +36,21 @@ function makeRule(md, options) {
 
       if (options.addHeadingAnchor) {
         var anchorToken = new state.Token('html_inline', '', 0);
+        var anchorContent = (options.linkify) ? headingInlineToken.content : '';
         anchorToken.content =
           '<a name="' +
           anchorName +
           '" class="' +
           options.anchorClass +
-          '" href="#"></a>';
+          '" href="#">'+
+          anchorContent +
+          '</a>';
 
         headingInlineToken.children.unshift(anchorToken);
+
+        if (options.linkify) {
+          headingInlineToken.children[1].content = '';
+        }
       }
 
       // Advance past the inline and heading_close tokens.
@@ -57,7 +64,8 @@ module.exports = function headinganchor_plugin(md, opts) {
     anchorClass: 'markdown-it-headinganchor',
     addHeadingID: true,
     addHeadingAnchor: true,
-    slugify: slugify
+    slugify: slugify,
+    linkify: true
   };
   var options = md.utils.assign(defaults, opts);
   md.core.ruler.push('heading_anchors', makeRule(md, options));


### PR DESCRIPTION
Super helpful plugin. Found myself wanting the heading to be clickable, so I added a `linkify` option.

If set to true, wrap heading content in anchor tag, making it into a true anchor link
