### PR TITLE
Make anchor tag clickable

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function makeRule(md, options) {
           anchorName +
           '" class="' +
           options.anchorClass +
-          '" href="#"></a>';
+          '" href="#' + anchorName + '"></a>';
 
         headingInlineToken.children.unshift(anchorToken);
       }


### PR DESCRIPTION
With this if the anchor is displayed along the title it could be clicked, right now if the user click it it will be scrolled to the top because it has `#` as `href`.